### PR TITLE
adding gulp-go support to gulpfile, allowing rebuild / rerun server o…

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,7 +1,7 @@
 // Modules
 var gulp = require('gulp');
 var gulpgo = require("gulp-go");
-var go;
+var go; //global var to store the PID of the go process
 var favicon = require ('gulp-real-favicon');
 var fs = require('fs');
 var runSequence = require('run-sequence');	// Using until gulp v4 is released
@@ -159,20 +159,19 @@ gulp.task('init', ['sass', 'javascript', 'jquery', 'bootstrap', 'underscore', 'f
 // Default - only run the tasks that change often
 gulp.task('default', ['sass', 'javascript']);
 
-
-gulp.task("go-run", function() {
-  go = gulpgo.run("blueprint.go", ["--arg1", "value1"], {cwd: __dirname, stdio: 'inherit'});
+//Go-run - run the program and store the pid for future use
+gulp.task('go-run', function() {
+  go = gulpgo.run('blueprint.go', ['--arg1', 'value1'], {cwd: __dirname, stdio: 'inherit'});
 });
 
-gulp.task("go", ["go-run"], function() {
-
+//Go - First run the go process, watch for any changes to tmpl or go, if changes then rebuild/restart
+gulp.task('go', ['go-run'], function() {
   gulp.watch(folderAsset + '/dynamic/sass/**/*.scss', ['sass']);
   gulp.watch(folderAsset + '/dynamic/js/*.js', ['javascript']);
-
-  gulp.watch([__dirname+"/**/*.go", ]).on("change", function() {
+  gulp.watch([__dirname + '/**/*.go']).on('change', function() {
     go.restart();
   });
-  gulp.watch([__dirname+"/**/*.tmpl", ]).on("change", function() {
+  gulp.watch([__dirname + '/**/*.tmpl']).on('change', function() {
     go.restart();
   });
 });

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,7 @@
 // Modules
 var gulp = require('gulp');
+var gulpgo = require("gulp-go");
+var go;
 var favicon = require ('gulp-real-favicon');
 var fs = require('fs');
 var runSequence = require('run-sequence');	// Using until gulp v4 is released
@@ -156,3 +158,21 @@ gulp.task('init', ['sass', 'javascript', 'jquery', 'bootstrap', 'underscore', 'f
 
 // Default - only run the tasks that change often
 gulp.task('default', ['sass', 'javascript']);
+
+
+gulp.task("go-run", function() {
+  go = gulpgo.run("blueprint.go", ["--arg1", "value1"], {cwd: __dirname, stdio: 'inherit'});
+});
+
+gulp.task("go", ["go-run"], function() {
+
+  gulp.watch(folderAsset + '/dynamic/sass/**/*.scss', ['sass']);
+  gulp.watch(folderAsset + '/dynamic/js/*.js', ['javascript']);
+
+  gulp.watch([__dirname+"/**/*.go", ]).on("change", function() {
+    go.restart();
+  });
+  gulp.watch([__dirname+"/**/*.tmpl", ]).on("change", function() {
+    go.restart();
+  });
+});

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "gulp-minify": "0.0.13",
     "gulp-real-favicon": "^0.2.1",
     "gulp-sass": "^2.3.2",
+    "gulp-go": "^1.1.0",
     "jquery": "1.9.1 - 2",
     "run-sequence": "^1.2.2",
     "underscore": "^1.8.3"


### PR DESCRIPTION
…n the fly

Obviously this adds the requirement of "gulp-go"

but at the same time this allows the user to just type "gulp go" and continue working without restarting the server for any reason.

this is my first time using gulp so maybe you know of a nicer way to do this?

thanks

