### PR TITLE
some fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,9 +22,9 @@ the Jay source code
 - [Core](https://github.com/blue-jay/core/issues) - issues related to
 the Core source code
 - [BlueJay Docs](https://github.com/blue-jay/blue-jay.github.io.hugo/issues)
-- issues related to the BlueJay website or documentation
+- Issues related to the BlueJay website or documentation
 
-When submitting a issue, please answer these questions:
+When submitting an issue, please answer these questions:
 
 - Which commit are you using?
 - Which operating system, processor architecture, and Go version are you using?

--- a/lib/flight/flight.go
+++ b/lib/flight/flight.go
@@ -54,7 +54,7 @@ type Info struct {
 
 // Context returns the application settings.
 func Context(w http.ResponseWriter, r *http.Request) Info {
-	id := ""
+	var id string
 
 	// Get the session
 	sess, err := configInfo.Session.Instance(r)

--- a/lib/flight/xsrf.go
+++ b/lib/flight/xsrf.go
@@ -1,4 +1,3 @@
-// Package flight provides access to the application settings safely.
 package flight
 
 import (

--- a/view/note/index.tmpl
+++ b/view/note/index.tmpl
@@ -23,7 +23,7 @@
 					</a>
 					
 					<form class="button-form" method="post" action="{{$.CurrentURI}}/{{.ID}}?_method=delete">
-						<button type="submit" class="btn btn-danger" />
+						<button onclick="return confirm('Are you sure?')" type="submit" class="btn btn-danger" />
 							<span class="glyphicon glyphicon-trash" aria-hidden="true"></span> Delete
 						</button>
 						<input type="hidden" name="_token" value="{{$.token}}">

--- a/viewfunc/prettytime/prettytime.go
+++ b/viewfunc/prettytime/prettytime.go
@@ -1,4 +1,4 @@
-// Package prettytime provides a funcmap for html/template to that displays
+// Package prettytime provides a funcmap for html/template that displays
 // time using an easy to read format.
 package prettytime
 


### PR DESCRIPTION
In [flight.go](https://github.com/blue-jay/blueprint/compare/master...tural-esger:master?expand=1#diff-f2e9418f46fa4d545b50aaf9e5b0edf9) change it to idiomatic Go variable declaration.

In [xsrf.go](https://github.com/blue-jay/blueprint/compare/master...tural-esger:master?expand=1#diff-7896e965e309c96c0f153e4ee47cb84e) redundant package comment. You did it in flight.go 

In [prettytime.go](https://github.com/blue-jay/blueprint/compare/master...tural-esger:master?expand=1#diff-727c706f869b924ed2a88f6016f6e7af) I think this sentence is not logical (If I am wrong, my apologies I am not native speaker).

